### PR TITLE
Fix issue in ViewModel: View is not refresh after delete all items

### DIFF
--- a/app/src/main/java/com/bawp/jetnote/screen/NoteViewModel.kt
+++ b/app/src/main/java/com/bawp/jetnote/screen/NoteViewModel.kt
@@ -29,6 +29,7 @@ class NoteViewModel @Inject constructor(private val repository: NoteRepository) 
                 .collect { listOfNotes ->
                      if (listOfNotes.isNullOrEmpty()) {
                          Log.d("Empty", ": Empty list")
+                         _noteList.value = emptyList()
                      }else {
                          _noteList.value = listOfNotes
                      }


### PR DESCRIPTION
When you delete all items of the list, View keep showing one item. Only is refreshed if you close and open again the application. It happens because ViewModel is not updated when list is empty.